### PR TITLE
Fix: podman rootless user namespace volume mount

### DIFF
--- a/container-run.sh
+++ b/container-run.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 VERSION=$(grep -oE "\"version\": \"(\w*.\w*.\w*.\w*.\w*.)" package.json | cut -d\" -f4)
+VOLUME_USERSPACE=""
 
 CONTAINER_ENGINE=$1
 if [ -z $CONTAINER_ENGINE ]; then
   CONTAINER_ENGINE=docker
+elif [ $CONTAINER_ENGINE = "podman" ]; then
+  # rootless podman will require mounting the volume as its uid/gid internally for proper permissions
+  VOLUME_USERSPACE=":U"
 fi
 
 echo using $CONTAINER_ENGINE container engine...
+echo Server now running at http://127.0.0.1:1880/
 
-$CONTAINER_ENGINE run -p 1880:1880 -v "$(pwd)"/data:/home/appuser/.node-red sparkle-guide:$VERSION &
+$CONTAINER_ENGINE run -d -p 1880:1880 -v "$(pwd)"/data:/home/appuser/.node-red$VOLUME_USERSPACE sparkle-guide:$VERSION


### PR DESCRIPTION
<!--

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

### Problem: Runtime permissions internally
Rootless podman will error out when running the current configuration. The non-root runtime of the container will result in permissions issues and an inability to write files to the mounted directory as intended. This 

see: https://www.tutorialworks.com/podman-rootless-volumes/

Also added the `-d` flag for the run command and removed standard background `&`

### Fix
Introduce the `:U` volume mount option to be appended to the volume mount parameter of the run command when using podman. 

### Manual Testing
Tested the runtime with docker, rootless podman, and podman as root. 


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have added suitable unit tests to cover the new/changed functionality
